### PR TITLE
Process evaporate options

### DIFF
--- a/ReactS3Uploader.js
+++ b/ReactS3Uploader.js
@@ -33,7 +33,7 @@ var ReactS3Uploader = createReactClass({
         s3path: PropTypes.string,
         inputRef: PropTypes.func,
         autoUpload: PropTypes.bool,
-        switchEvaporateOptions: PropTypes.func,
+        processEvaporateOptions: PropTypes.func,
         evaporateOptions: PropTypes.object.isRequired,
     },
 
@@ -59,7 +59,7 @@ var ReactS3Uploader = createReactClass({
             },
             s3path: '',
             autoUpload: true,
-            switchEvaporateOptions: function (options, file) {
+            processEvaporateOptions: function (options, file) {
                 return options;
             }
         };
@@ -83,7 +83,7 @@ var ReactS3Uploader = createReactClass({
             contentDisposition: this.props.contentDisposition,
             server: this.props.server,
             scrubFilename: this.props.scrubFilename,
-            switchEvaporateOptions: this.props.switchEvaporateOptions,
+            processEvaporateOptions: this.props.processEvaporateOptions,
             s3path: this.props.s3path
         });
     },

--- a/ReactS3Uploader.js
+++ b/ReactS3Uploader.js
@@ -33,6 +33,7 @@ var ReactS3Uploader = createReactClass({
         s3path: PropTypes.string,
         inputRef: PropTypes.func,
         autoUpload: PropTypes.bool,
+        switchEvaporateOptions: PropTypes.func,
         evaporateOptions: PropTypes.object.isRequired,
     },
 
@@ -57,7 +58,10 @@ var ReactS3Uploader = createReactClass({
                 return filename.replace(/[^\w\d_\-\.]+/ig, '');
             },
             s3path: '',
-            autoUpload: true
+            autoUpload: true,
+            switchEvaporateOptions: function (options, file) {
+                return options;
+            }
         };
     },
 
@@ -79,6 +83,7 @@ var ReactS3Uploader = createReactClass({
             contentDisposition: this.props.contentDisposition,
             server: this.props.server,
             scrubFilename: this.props.scrubFilename,
+            switchEvaporateOptions: this.props.switchEvaporateOptions,
             s3path: this.props.s3path
         });
     },
@@ -106,7 +111,7 @@ var ReactS3Uploader = createReactClass({
         if ( this.props.autoUpload ) {
             additional.onChange = this.uploadFile;
         }
-        
+
         var temporaryProps = objectAssign({}, this.props, additional);
         var inputProps = {};
 

--- a/s3upload.js
+++ b/s3upload.js
@@ -63,6 +63,7 @@ S3Upload.prototype.uploadToS3 = function(file) {
     var evaporateOptions = Object.assign(this.evaporateOptions, {
         signerUrl: this.signingUrl
     });
+    console.log('s3upload:uploadToS3', evaporateOptions, file);
     return Evaporate.create(evaporateOptions).then(function(evaporate){
       var addConfig = {
         name: this.s3path + this.scrubFilename(file.name),

--- a/s3upload.js
+++ b/s3upload.js
@@ -34,8 +34,8 @@ S3Upload.prototype.scrubFilename = function(filename) {
     return filename.replace(/[^\w\d_\-\.]+/ig, '');
 };
 
-S3Upload.prototype.switchEvaporateOptions = function(options, file) {
-    return options;
+S3Upload.prototype.processEvaporateOptions = function(defaultOptions, file) {
+    return defaultOptions;
 };
 
 function S3Upload(options) {
@@ -67,9 +67,7 @@ S3Upload.prototype.uploadToS3 = function(file) {
     var evaporateOptions = Object.assign(this.evaporateOptions, {
         signerUrl: this.signingUrl
     });
-    console.log('s3upload:uploadToS3', evaporateOptions, file);
-    this.switchEvaporateOptions(evaporateOptions, file);
-    return Evaporate.create(evaporateOptions).then(function(evaporate){
+    return Evaporate.create(this.processEvaporateOptions(evaporateOptions, file)).then(function(evaporate){
       var addConfig = {
         name: this.s3path + this.scrubFilename(file.name),
         file: file,

--- a/s3upload.js
+++ b/s3upload.js
@@ -34,6 +34,10 @@ S3Upload.prototype.scrubFilename = function(filename) {
     return filename.replace(/[^\w\d_\-\.]+/ig, '');
 };
 
+S3Upload.prototype.switchEvaporateOptions = function(options, file) {
+    return options;
+};
+
 function S3Upload(options) {
     if (options == null) {
         options = {};
@@ -64,6 +68,7 @@ S3Upload.prototype.uploadToS3 = function(file) {
         signerUrl: this.signingUrl
     });
     console.log('s3upload:uploadToS3', evaporateOptions, file);
+    this.switchEvaporateOptions(evaporateOptions, file);
     return Evaporate.create(evaporateOptions).then(function(evaporate){
       var addConfig = {
         name: this.s3path + this.scrubFilename(file.name),


### PR DESCRIPTION
### Changes:
- Added the prop `processEvaporateOptions` that allows to transform/modify the evaporate options for each upload

### Why?
To be able to upload with different aws configurations (like different buckets) depending on the file attributes (like the type).
 
### Example
```javascript
processEvaporateOptions={(options: any, file: any) => {
  const fileType = file.type.split("/")[0];
  switch (fileType) {
    case 'video':
      return { ...options, awsRegion: AWS_REGION, bucket: S3_BUCKET };
    case 'image':
      return { ...options, awsRegion: AWS_IMAGES_REGION, bucket: S3_IMAGES_BUCKET };
    default:
      return options;
  }
}}
```
