### PR TITLE
Add process evaporate config

### DIFF
--- a/ReactS3Uploader.js
+++ b/ReactS3Uploader.js
@@ -33,6 +33,8 @@ var ReactS3Uploader = createReactClass({
         s3path: PropTypes.string,
         inputRef: PropTypes.func,
         autoUpload: PropTypes.bool,
+        processEvaporateOptions: PropTypes.func,
+        processEvaporateConfig: PropTypes.func,
         evaporateOptions: PropTypes.object.isRequired,
     },
 
@@ -57,7 +59,13 @@ var ReactS3Uploader = createReactClass({
                 return filename.replace(/[^\w\d_\-\.]+/ig, '');
             },
             s3path: '',
-            autoUpload: true
+            autoUpload: true,
+            processEvaporateOptions: function (options, file) {
+                return options;
+            },
+            processEvaporateConfig: function (config, file) {
+                return config;
+            }
         };
     },
 
@@ -79,6 +87,8 @@ var ReactS3Uploader = createReactClass({
             contentDisposition: this.props.contentDisposition,
             server: this.props.server,
             scrubFilename: this.props.scrubFilename,
+            processEvaporateOptions: this.props.processEvaporateOptions,
+            processEvaporateConfig: this.props.processEvaporateConfig,
             s3path: this.props.s3path
         });
     },
@@ -106,7 +116,7 @@ var ReactS3Uploader = createReactClass({
         if ( this.props.autoUpload ) {
             additional.onChange = this.uploadFile;
         }
-        
+
         var temporaryProps = objectAssign({}, this.props, additional);
         var inputProps = {};
 

--- a/s3upload.js
+++ b/s3upload.js
@@ -34,6 +34,14 @@ S3Upload.prototype.scrubFilename = function(filename) {
     return filename.replace(/[^\w\d_\-\.]+/ig, '');
 };
 
+S3Upload.prototype.processEvaporateOptions = function(defaultOptions, file) {
+    return defaultOptions;
+};
+
+S3Upload.prototype.processEvaporateConfig = function(defaultConfig, file) {
+    return defaultConfig;
+};
+
 function S3Upload(options) {
     if (options == null) {
         options = {};
@@ -63,7 +71,7 @@ S3Upload.prototype.uploadToS3 = function(file) {
     var evaporateOptions = Object.assign(this.evaporateOptions, {
         signerUrl: this.signingUrl
     });
-    return Evaporate.create(evaporateOptions).then(function(evaporate){
+    return Evaporate.create(this.processEvaporateOptions(evaporateOptions, file)).then(function(evaporate){
       var addConfig = {
         name: this.s3path + this.scrubFilename(file.name),
         file: file,
@@ -83,7 +91,7 @@ S3Upload.prototype.uploadToS3 = function(file) {
         }.bind(this)
       };
       this.evaporate = evaporate;
-      evaporate.add(addConfig).then(
+      evaporate.add(this.processEvaporateConfig(addConfig, file)).then(
         function(awsKey){
           return this.onFinishS3Put(awsKey, file);
         }.bind(this),

--- a/s3upload.js
+++ b/s3upload.js
@@ -73,7 +73,7 @@ S3Upload.prototype.uploadToS3 = function(file) {
     });
     return Evaporate.create(this.processEvaporateOptions(evaporateOptions, file)).then(function(evaporate){
       var addConfig = {
-        name: this.s3path + this.scrubFilename(file.name),
+        name: this.scrubFilename(file.name),
         file: file,
         contentType: file.type,
         progress: function(p, stats){
@@ -91,7 +91,7 @@ S3Upload.prototype.uploadToS3 = function(file) {
         }.bind(this)
       };
       this.evaporate = evaporate;
-      evaporate.add(this.processEvaporateConfig(addConfig, file)).then(
+      evaporate.add(this.processEvaporateConfig(addConfig, file, this.s3path)).then(
         function(awsKey){
           return this.onFinishS3Put(awsKey, file);
         }.bind(this),


### PR DESCRIPTION
## Changes:
Added the prop processEvaporateConfig that allows to transform/modify the evaporate config for each upload.

## Why?
To be able to upload with different aws configurations (for example different s3Path).

## Example
```js
processEvaporateConfig={(config: any, file: any) => {
  const fileType = file.type.split("/")[0];
  switch (fileType) {
    case 'video':
      return { ...config, s3Path: '/videos' };
    case 'image':
      return { ...config, s3Path: '/images' };
    default:
      return config;
  }
}}
```